### PR TITLE
Make self-hosting work out of the box (account_id, D1/KV IDs, vars block)

### DIFF
--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -184,18 +184,11 @@ if (!accountId) {
   }
 }
 
-// Inject into environment so all subsequent wrangler calls use this account
+// Inject into environment so all subsequent wrangler calls use this account.
+// wrangler.jsonc intentionally omits `account_id` so the project is portable —
+// wrangler picks up the account from CLOUDFLARE_ACCOUNT_ID, the OAuth session,
+// or a scoped API token. See docs/CLOUDFLARE.md.
 process.env.CLOUDFLARE_ACCOUNT_ID = accountId;
-
-// Patch wrangler.jsonc with the account_id
-{
-  let jsonc = readFileSync(WRANGLER_JSONC, 'utf8');
-  if (jsonc.includes('REPLACE_WITH_CF_ACCOUNT_ID')) {
-    jsonc = jsonc.replace(/REPLACE_WITH_CF_ACCOUNT_ID/g, accountId);
-    writeFileSync(WRANGLER_JSONC, jsonc, 'utf8');
-    ok('wrangler.jsonc patched with account_id.');
-  }
-}
 
 // ─── step 2: create D1 database ─────────────────────────────────────────────
 

--- a/services/worker/wrangler.jsonc
+++ b/services/worker/wrangler.jsonc
@@ -31,7 +31,6 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-05-01",
   "compatibility_flags": ["nodejs_compat"],
-  "account_id": "532cea73d241b8513e953d361cc25176",
   "workers_dev": true,
   "preview_urls": false,
 
@@ -57,7 +56,7 @@
     {
       "binding": "DB",
       "database_name": "emailflare",
-      "database_id": "569d845e-5691-4f71-84f6-e31a878e4bd6",
+      "database_id": "REPLACE_WITH_D1_DATABASE_ID",
       "migrations_dir": "migrations"
     }
   ],
@@ -66,18 +65,17 @@
   "kv_namespaces": [
     {
       "binding": "RATE_LIMIT_KV",
-      "id": "dd700ff5c7fd4a77ae4acee19bfcd215"
+      "id": "REPLACE_WITH_KV_NAMESPACE_ID"
     }
   ],
 
-  // Runtime env vars (Localflare reads vars from config for manifest visibility).
-  // Production values should be set with `wrangler secret put`.
+  // Local-dev defaults read by Localflare for manifest visibility.
+  // Sensitive values (ADMIN_TOKEN, SESSION_SECRET, CF_API_TOKEN, CF_ACCOUNT_ID)
+  // and per-deploy values (ADMIN_ORIGIN in production) are set via
+  // `wrangler secret put`. A Worker cannot have a `var` and a `secret`
+  // with the same name — the `secret put` call fails with code 10053.
   "vars": {
-    "ADMIN_ORIGIN": "localhost:5173",
-    "ADMIN_TOKEN": "set-via-secret",
-    "SESSION_SECRET": "set-via-secret",
-    "CF_API_TOKEN": "set-via-secret",
-    "CF_ACCOUNT_ID": "set-via-secret"
+    "ADMIN_ORIGIN": "localhost:5173"
   },
 
   // Workers Rate Limiting for API key calls (100 req / 60s per key)


### PR DESCRIPTION
Fixes #3.

A self-hostable Cloudflare Worker template should not commit a specific account's resource IDs, nor plaintext placeholder `vars` for things that should be secrets. The currently-committed `services/worker/wrangler.jsonc` has three independent issues that each block `just worker-setup` on a fresh account.

## The three issues

### 1. Hardcoded `account_id`

`scripts/setup.mjs` is designed to patch `REPLACE_WITH_CF_ACCOUNT_ID` into the real account ID at first-time setup, but the placeholder is no longer present — it was replaced with a literal account ID at some point — so the patch step no-ops with:

```
⚠ wrangler.jsonc already has real IDs — skipping patch (already configured).
```

`wrangler` then tries to talk to the wrong account:

```
✘ [ERROR] A request to the Cloudflare API (/accounts/<wrong-id>/d1/database) failed.
  Authentication error [code: 10000]
```

### 2. Hardcoded `d1_databases[0].database_id` and `kv_namespaces[0].id`

Same regression on the D1 and KV placeholders. After issue 1 is fixed, setup proceeds and `wrangler d1 create` / `kv namespace create` succeed against your account. But because the patch step (the same one as above) saw real-looking IDs, it skips patching them too, so the next step fails:

```
✘ [ERROR] /accounts/<your-id>/d1/database/<upstream-id>/query
  The database <upstream-id> could not be found [code: 7404]
```

### 3. Plaintext `"set-via-secret"` vars for things that should be secrets

The `vars` block contains:

```jsonc
"vars": {
  "ADMIN_ORIGIN": "localhost:5173",
  "ADMIN_TOKEN": "set-via-secret",
  "SESSION_SECRET": "set-via-secret",
  "CF_API_TOKEN": "set-via-secret",
  "CF_ACCOUNT_ID": "set-via-secret"
}
```

A Worker cannot have a `var` and a `secret` with the same name, so `setup.mjs`'s `wrangler secret put ADMIN_TOKEN` step fails with:

```
✘ [ERROR] /accounts/<id>/workers/scripts/emailflare-worker/secrets
  Binding name 'ADMIN_TOKEN' already in use. [code: 10053]
```

`setup.mjs` only warns and continues, so every subsequent `secret put` hits the same wall and the worker deploys with zero secrets — `wrangler secret list` returns `[]`. Admin login then fails because `c.env.ADMIN_TOKEN` is undefined at runtime.

## What this PR does

- **`services/worker/wrangler.jsonc`**: restores the three placeholders `setup.mjs` already knows about (`REPLACE_WITH_CF_ACCOUNT_ID`, `REPLACE_WITH_D1_DATABASE_ID`, `REPLACE_WITH_KV_NAMESPACE_ID`). Also drops `account_id` entirely — wrangler resolves the account from the OAuth session, `CLOUDFLARE_ACCOUNT_ID` env var, or a scoped API token, so committing it is unnecessary and locks the template to one account ([wrangler docs](https://developers.cloudflare.com/workers/wrangler/configuration/#account-id)).

- **`services/worker/wrangler.jsonc`**: removes the four `"set-via-secret"` entries from the `vars` block. They served no runtime purpose (the secret values are what the worker actually reads) and they actively prevented those secrets from being set. `ADMIN_ORIGIN` stays in `vars` since it has a real local-dev default and isn't set as a secret in local dev.

- **`scripts/setup.mjs`**: drops the now-redundant `account_id` patching block. The script already exports `CLOUDFLARE_ACCOUNT_ID` to the environment immediately above (currently line 188), which `wrangler` picks up for every subsequent call.

## How I tested

- Cloned `trunk` (`5985561e`). Confirmed `just worker-setup` fails with `Authentication error [code: 10000]` against the upstream-committed `account_id`.
- Applied this change locally. Re-ran `just worker-setup` against my own Cloudflare account. Setup:
  - resolved my account from `wrangler whoami`
  - created D1 (`emailflare`) and KV (`emailflare-rate-limit`)
  - patched `wrangler.jsonc` with the new D1/KV IDs (the patch step actually fires now)
  - applied migrations and deployed
  - **`wrangler secret put` for ADMIN_TOKEN etc. fails** because of issue 3 — that's the failure that prompted the vars-block portion of this PR.
- After also removing the four `"set-via-secret"` entries from `vars` and redeploying, `wrangler secret put ADMIN_TOKEN | SESSION_SECRET | CF_ACCOUNT_ID` succeeds and `wrangler secret list` shows the three entries. (Admin-UI login verification is in progress on the deployed worker; I'll update this PR with the result if you want it before merging.)

## Optional follow-ups (out of scope here)

- **Secret-put ordering bug**: `setup.mjs` runs `wrangler secret put` *before* `wrangler deploy`, which on a fresh account fails because the worker doesn't exist yet. The script warns and continues, so the first-time setup deploys with zero secrets. Moving the secrets loop after the first `wrangler deploy` (or running a deploy-then-secrets-then-redeploy sequence) would fix this. Happy to file a separate issue / PR if useful.
- A `.gitattributes` filter or pre-commit hook so future edits don't accidentally re-commit account/resource IDs into `wrangler.jsonc`.