### PR TITLE
security: add CODEOWNERS to require owner review for workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Any changes to GitHub Actions workflows require owner approval.
+.github/workflows/ @0xdps
+
+# CODEOWNERS itself requires owner approval.
+.github/CODEOWNERS @0xdps


### PR DESCRIPTION
Requires @0xdps approval on any changes to `.github/workflows/` and `.github/CODEOWNERS` to prevent unauthorized CI/CD modifications like the recent supply chain attack.