### PR TITLE
fix(cloudflare): send reply_to (snake_case) to CF Email Service REST API

### DIFF
--- a/services/backend/src/services/cloudflare.ts
+++ b/services/backend/src/services/cloudflare.ts
@@ -166,9 +166,14 @@ export interface CFSendEmailResult {
 }
 
 export async function sendEmail(params: CFSendEmailParams): Promise<CFSendEmailResult> {
+  // The Cloudflare Email Service REST API expects snake_case `reply_to`; our
+  // params use camelCase `replyTo`. Map it (and omit when absent) — CF's schema
+  // is strict and rejects unknown fields with invalid_request_schema.
+  const { replyTo, ...rest } = params;
+  const body = { ...rest, ...(replyTo ? { reply_to: replyTo } : {}) };
   return cfFetch<CFSendEmailResult>(`/accounts/${env.CF_ACCOUNT_ID}/email/sending/send`, {
     method: 'POST',
-    body: JSON.stringify(params),
+    body: JSON.stringify(body),
   });
 }
 

--- a/services/worker/src/services/cloudflare.ts
+++ b/services/worker/src/services/cloudflare.ts
@@ -197,10 +197,15 @@ export async function sendEmail(
   cfApiToken: string,
   cfAccountId: string,
 ): Promise<CFSendEmailResult> {
+  // The Cloudflare Email Service REST API expects snake_case `reply_to`; our
+  // params use camelCase `replyTo`. Map it (and omit when absent) — CF's schema
+  // is strict and rejects unknown fields with invalid_request_schema.
+  const { replyTo, ...rest } = params;
+  const body = { ...rest, ...(replyTo ? { reply_to: replyTo } : {}) };
   return cfFetch<CFSendEmailResult>(
     `/accounts/${cfAccountId}/email/sending/send`,
     cfApiToken,
-    { method: 'POST', body: JSON.stringify(params) },
+    { method: 'POST', body: JSON.stringify(body) },
   );
 }
 


### PR DESCRIPTION
## Problem

`sendEmail()` (both `services/backend/src/services/cloudflare.ts` and `services/worker/src/services/cloudflare.ts`) builds the request body with `JSON.stringify(params)`, where `params` (`CFSendEmailParams`) carries a **camelCase `replyTo`** field.

The Cloudflare Email Service REST API (`POST /accounts/{account_id}/email/sending/send`) expects **snake_case `reply_to`** and validates the body against a strict schema that rejects unknown fields. So any send that sets `replyTo` fails with:

```json
{"success":false,"errors":[{"code":10001,"message":"email.sending.error.invalid_request_schema"}]}
```

(HTTP 400). Sends *without* `replyTo` succeed because the unknown field is simply absent — which makes this easy to miss until a Reply-To is actually needed.

## Verification

Direct CF API call, identical body otherwise:

- `reply_to` (snake_case) → `200`, `success: true`
- `replyTo` (camelCase) → `400`, `email.sending.error.invalid_request_schema`

CF docs list the field as `reply_to`: https://developers.cloudflare.com/email-service/api/send-emails/rest-api/

## Fix

Destructure `replyTo` out of the params and send it as `reply_to`, omitting when absent. No behavior change when `replyTo` is unset. Applied to both the backend and worker `sendEmail` implementations.