### PR TITLE
fix(migrations): remove duplicate body_text migration that breaks fresh installs

### DIFF
--- a/migrations/0003_add_sent_body_text.sql
+++ b/migrations/0003_add_sent_body_text.sql
@@ -1,5 +1,0 @@
--- Migration: add body_text to sent_inbox_emails
--- The compose endpoint stores the outbound message body so it can be displayed
--- in the thread view alongside inbound emails.
-
-ALTER TABLE sent_inbox_emails ADD COLUMN body_text TEXT;


### PR DESCRIPTION
Fixes #102

## Problem

`migrations/0001_schema.sql` already declares `body_text TEXT` on `sent_inbox_emails` (consolidated in 46c718b), but `0003_add_sent_body_text.sql` was shipped alongside it as an `ALTER TABLE ... ADD COLUMN` for the same column. Applying the migrations directory in order on a **fresh** database fails:

```
Parse error near line 5: duplicate column name: body_text
```

This breaks `wrangler d1 migrations apply` for a first-time `just emailflare-api-worker-setup` / `just emailflare-inbox-deploy`, and the Docker inbox-server exits on boot because `runMigrations()` rethrows and `index.ts` calls `process.exit(1)`.

## Fix

Delete `0003_add_sent_body_text.sql`. Nothing in the repo references it.

This is safe for already-deployed databases: both `wrangler d1 migrations` and `services/inbox-server/src/migrate.ts` only apply files whose names are **not** recorded in their migrations table, so a DB that has 0003 recorded is untouched, and a DB that never saw it doesn't need it (the column is in 0001).

## Verification

Applied `migrations/*.sql` in order to an empty SQLite database:

- on `trunk`: fails on 0003 with the error above
- on this branch: 0001 + 0002 apply cleanly; `PRAGMA table_info(sent_inbox_emails)` still lists `body_text`; 20 tables created

Also confirmed on the Workers path with `wrangler d1 migrations apply DB --local` against a fresh local D1:

- trunk's three files: 0001 ✅, 0002 ✅, 0003 → `duplicate column name: body_text: SQLITE_ERROR`
- this branch: 0001 ✅, 0002 ✅
