### PR TITLE
fix(api): clamp pagination limit/page so ?limit=-1 can't dump whole tables

### DIFF
--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -212,6 +212,38 @@ export function shortId(n = 4): string {
 	return generateId().slice(0, n);
 }
 
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+export interface Pagination {
+	page: number;
+	limit: number;
+	offset: number;
+}
+
+/**
+ * Parse `?page=&limit=` query params into clamped, always-valid pagination.
+ *
+ * - non-numeric or missing values fall back to the defaults
+ * - `page` is clamped to >= 1
+ * - `limit` is clamped to 1..maxLimit (SQLite treats LIMIT 0/negative as
+ *   "no limit", which would let `?limit=-1` dump an entire table)
+ */
+export function parsePagination(
+	query: { page?: string; limit?: string },
+	opts: { defaultLimit?: number; maxLimit?: number } = {},
+): Pagination {
+	const defaultLimit = opts.defaultLimit ?? 50;
+	const maxLimit = opts.maxLimit ?? 100;
+
+	const rawPage = parseInt(query.page ?? "", 10);
+	const rawLimit = parseInt(query.limit ?? "", 10);
+
+	const page = Number.isFinite(rawPage) ? Math.max(1, rawPage) : 1;
+	const limit = Number.isFinite(rawLimit) ? Math.min(maxLimit, Math.max(1, rawLimit)) : defaultLimit;
+
+	return { page, limit, offset: (page - 1) * limit };
+}
+
 // ── CSP-safe Handlebars-compatible template renderer ──────────────────────
 //
 // Cloudflare Workers block `new Function()` / `eval()` (CSP), so Handlebars

--- a/services/email-server/src/routes/logs.ts
+++ b/services/email-server/src/routes/logs.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { db, emailLogs } from "../db.js";
 
 const app = new Hono();
@@ -10,9 +11,7 @@ interface CountRow {
 
 // GET /api/logs?page=1&limit=50&domainId=&status=&templateId=&apiKeyId=&search=&from=&to=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const domainId = c.req.query("domainId");
 	const status = c.req.query("status");
 	const templateId = c.req.query("templateId");

--- a/services/email-server/src/routes/suppressions.ts
+++ b/services/email-server/src/routes/suppressions.ts
@@ -6,16 +6,14 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { generateId } from "@emailflare/email-core";
+import { generateId, parsePagination } from "@emailflare/email-core";
 import { db } from "../db.js";
 
 export const suppressionsRoutes = new Hono();
 
 // GET /api/suppressions?page=1&limit=50&reason=&search=
 suppressionsRoutes.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const reason = c.req.query("reason");
 	const search = c.req.query("search");
 

--- a/services/email-server/src/routes/testEmails.ts
+++ b/services/email-server/src/routes/testEmails.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { db, emailLogs } from "../db.js";
 
 const app = new Hono();
@@ -10,9 +11,7 @@ interface CountRow {
 
 // GET /api/test-emails?page=1&limit=50&domainId=&search=&from=&to=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const domainId = c.req.query("domainId");
 	const search = c.req.query("search");
 	const fromDate = c.req.query("from"); // ISO date string

--- a/services/email-worker/src/routes/logs.ts
+++ b/services/email-worker/src/routes/logs.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { D1Db } from "../db.ts";
 import type { HonoEnv } from "../env.ts";
 
@@ -6,9 +7,7 @@ const app = new Hono<HonoEnv>();
 
 // GET /api/logs?page=1&limit=50&domainId=&status=&templateId=&apiKeyId=&search=&from=&to=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const domainId = c.req.query("domainId");
 	const status = c.req.query("status");
 	const templateId = c.req.query("templateId");

--- a/services/email-worker/src/routes/suppressions.ts
+++ b/services/email-worker/src/routes/suppressions.ts
@@ -6,7 +6,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { generateId } from "@emailflare/email-core";
+import { generateId, parsePagination } from "@emailflare/email-core";
 import { D1Db } from "../db.ts";
 import type { HonoEnv } from "../env.ts";
 
@@ -14,9 +14,7 @@ const app = new Hono<HonoEnv>();
 
 // GET /api/suppressions?page=1&limit=50&reason=&search=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const reason = c.req.query("reason");
 	const search = c.req.query("search");
 

--- a/services/inbox-server/src/routes/inbox/people.ts
+++ b/services/inbox-server/src/routes/inbox/people.ts
@@ -1,14 +1,13 @@
 // People CRM routes
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { rawDb } from "../../db.js";
 import type { HonoEnv } from "../../env.js";
 
 const app = new Hono<HonoEnv>();
 
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const search = c.req.query("search");
 	const unread = c.req.query("unread") === "1";
 
@@ -58,9 +57,7 @@ app.get("/:id", async (c) => {
 
 app.get("/:id/thread", async (c) => {
 	const personId = c.req.param("id");
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 
 	const person = await rawDb.first("SELECT * FROM people WHERE id = ? LIMIT 1", [personId]);
 	if (!person) return c.json({ error: "Person not found" }, 404);

--- a/services/inbox-server/src/routes/logs.ts
+++ b/services/inbox-server/src/routes/logs.ts
@@ -1,13 +1,12 @@
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { rawDb } from "../db.js";
 import type { HonoEnv } from "../env.js";
 
 const app = new Hono<HonoEnv>();
 
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const domainId = c.req.query("domainId");
 	const status = c.req.query("status");
 	const templateId = c.req.query("templateId");

--- a/services/inbox-server/src/routes/suppressions.ts
+++ b/services/inbox-server/src/routes/suppressions.ts
@@ -6,16 +6,14 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { generateId } from "@emailflare/email-core";
+import { generateId, parsePagination } from "@emailflare/email-core";
 import { makeDb, rawDb } from "../db.js";
 
 const app = new Hono();
 
 // GET /api/suppressions?page=1&limit=50&reason=&search=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const reason = c.req.query("reason");
 	const search = c.req.query("search");
 

--- a/services/inbox-server/src/routes/testEmails.ts
+++ b/services/inbox-server/src/routes/testEmails.ts
@@ -4,15 +4,14 @@
 // DELETE /api/test-emails/:id
 
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { makeDb, rawDb } from "../db.js";
 
 const app = new Hono();
 
 // GET /api/test-emails — paginated test emails only (is_test = 1)
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const search = c.req.query("search");
 	const from = c.req.query("from");
 	const to = c.req.query("to");

--- a/services/inbox-worker/src/routes/inbox/people.ts
+++ b/services/inbox-worker/src/routes/inbox/people.ts
@@ -5,15 +5,14 @@
 // GET  /api/inbox/people/:id/thread         — email thread (inbox + sent)
 
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import type { HonoEnv } from "../../env.ts";
 
 const app = new Hono<HonoEnv>();
 
 // GET /api/inbox/people
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const search = c.req.query("search");
 	const unread = c.req.query("unread") === "1";
 
@@ -68,9 +67,7 @@ app.get("/:id", async (c) => {
 // GET /api/inbox/people/:id/thread
 app.get("/:id/thread", async (c) => {
 	const personId = c.req.param("id");
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 
 	const person = await c.env.DB.prepare("SELECT * FROM people WHERE id = ? LIMIT 1").bind(personId).first();
 	if (!person) return c.json({ error: "Person not found" }, 404);

--- a/services/inbox-worker/src/routes/logs.ts
+++ b/services/inbox-worker/src/routes/logs.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { D1Db } from "../db.ts";
 import type { HonoEnv } from "../env.ts";
 
@@ -6,9 +7,7 @@ const app = new Hono<HonoEnv>();
 
 // GET /api/logs?page=1&limit=50&domainId=&status=&templateId=&apiKeyId=&search=&from=&to=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const domainId = c.req.query("domainId");
 	const status = c.req.query("status");
 	const templateId = c.req.query("templateId");

--- a/services/inbox-worker/src/routes/suppressions.ts
+++ b/services/inbox-worker/src/routes/suppressions.ts
@@ -6,7 +6,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { generateId } from "@emailflare/email-core";
+import { generateId, parsePagination } from "@emailflare/email-core";
 import { makeDb } from "../db.ts";
 import type { HonoEnv } from "../env.ts";
 
@@ -14,9 +14,7 @@ const app = new Hono<HonoEnv>();
 
 // GET /api/suppressions?page=1&limit=50&reason=&search=
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const reason = c.req.query("reason");
 	const search = c.req.query("search");
 

--- a/services/inbox-worker/src/routes/testEmails.ts
+++ b/services/inbox-worker/src/routes/testEmails.ts
@@ -4,6 +4,7 @@
 // DELETE /api/test-emails/:id
 
 import { Hono } from "hono";
+import { parsePagination } from "@emailflare/email-core";
 import { makeDb } from "../db.ts";
 import type { HonoEnv } from "../env.ts";
 
@@ -11,9 +12,7 @@ const app = new Hono<HonoEnv>();
 
 // GET /api/test-emails — paginated test emails only (is_test = 1)
 app.get("/", async (c) => {
-	const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
-	const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
-	const offset = (page - 1) * limit;
+	const { page, limit, offset } = parsePagination({ page: c.req.query("page"), limit: c.req.query("limit") });
 	const search = c.req.query("search");
 	const from = c.req.query("from");
 	const to = c.req.query("to");


### PR DESCRIPTION
Fixes #103

## Problem

Every paginated list handler parsed its query as

```ts
const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
const limit = Math.min(100, parseInt(c.req.query("limit") ?? "50", 10));
```

which caps `limit` from above only and never checks for `NaN`:

- `?limit=-1` → SQLite treats negative `LIMIT` as "no limit", so the endpoint returned the **whole table** (on `/api/logs` including stored `html_body`/`text_body`)
- `?limit=0` → `pages: null`
- `?limit=abc` / `?page=abc` → `NaN` bound into D1 → `datatype mismatch: SQLITE_MISMATCH` → **500**

Full reproduction in #103.

## Fix

Add `parsePagination()` to `@emailflare/email-core` (every service already depends on it):

- non-numeric / missing → defaults (`page 1`, `limit 50`)
- `page` clamped to ≥ 1
- `limit` clamped to 1..100

and replace the hand-rolled block in all 13 handlers (email-worker, inbox-worker, email-server, inbox-server). No behaviour change for valid input; response shape unchanged.

## Verification

- Helper checked against the built package for `{}`, `-1`, `0`, `abc`, `1000`, negative page, and a normal `page=3&limit=20` (offset 40): all as expected.
- `tsc --noEmit` clean in email-core and all four services; prettier clean.
- Same local Worker as #103 (`wrangler dev`, fresh D1, 250 seeded rows):

| Request | Before | After |
|---|---|---|
| `?limit=-1` | 250 rows, `pages: -250` | 1 row, `pages: 250` |
| `?limit=0` | `pages: null` | 1 row |
| `?limit=abc` | 500 | 50 rows (default) |
| `?page=abc` | 500 | page 1 |
| `?limit=1000` | 100 | 100 |
| `?page=3&limit=20` | 20 rows | 20 rows, offset 40 |
